### PR TITLE
Jonathan holloway

### DIFF
--- a/frontend/src/store/actions/FollowersActions.js
+++ b/frontend/src/store/actions/FollowersActions.js
@@ -24,6 +24,10 @@ export const REMOVE_FOLLOWER = "REMOVE_FOLLOWER";
 export const REMOVE_FOLLOWER_SUCCESS = "REMOVE_FOLLOWER_SUCCESS";
 export const REMOVE_FOLLOWER_FAILURE = "REMOVE_FOLLOWER_FAILURE";
 
+export const GET_FOLLOWING = "GET_FOLLOWING";
+export const GET_FOLLOWING_SUCCESSFUL = "GET_FOLLOWING_SUCCESSFUL";
+export const GET_FOLLOWING_FAILURE = "GET_FOLLOWING_FAILURE";
+
 /***************************************************************************************************
  ********************************************* Actions *******************************************
  **************************************************************************************************/
@@ -78,3 +82,16 @@ export const addFollower = (userId, following_id) => dispatch => {
       dispatch({type: ADD_FOLLOWER_FAILURE, err: "A user cannot follow themselves"});
   }
 };
+
+//Get count of users following a user 
+export const followersCount = (userId) => dispatch => {
+  const token = localStorage.getItem("symposium_token");
+  const headers = { headers: {Authorization: token }};
+  dispatch ({type: GET_FOLLOWING})
+  return axios
+    .get(`${backendURL}/followers/following/${userId}`)
+    .then((res) => dispatch({type: GET_FOLLOWING_SUCCESSFUL, payload: res.data}))
+    .catch(err => handleError(err, GET_FOLLOWING_FAILURE)(dispatch));
+}
+
+

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -328,12 +328,17 @@ import {
   REMOVE_FOLLOWER,
   REMOVE_FOLLOWER_SUCCESS,
   REMOVE_FOLLOWER_FAILURE,
+  GET_FOLLOWING, 
+  GET_FOLLOWING_SUCCESSFUL,
+  GET_FOLLOWING_FAILURE, 
+ 
 
   //FOLLOW CREATORS
   getFollowers,
   getProfileFollowers,
   removeFollower,
-  addFollower
+  addFollower,
+  followersCount,
 } from '../actions/FollowersActions.js';
 
 import {
@@ -656,11 +661,15 @@ export {
   REMOVE_FOLLOWER,
   REMOVE_FOLLOWER_SUCCESS,
   REMOVE_FOLLOWER_FAILURE,
+  GET_FOLLOWING, 
+  GET_FOLLOWING_SUCCESSFUL,
+  GET_FOLLOWING_FAILURE,
   //FOLLOW CREATORS
   getFollowers,
   getProfileFollowers,
   removeFollower,
   addFollower,
+  followersCount,
   //INVITE A FRIEND
   SENDING_INVITE,
   SENDING_INVITE_FAILURE,

--- a/frontend/src/store/reducers/FollowersReducer.js
+++ b/frontend/src/store/reducers/FollowersReducer.js
@@ -10,7 +10,10 @@ import {
   ADD_FOLLOWER_FAILURE,
   REMOVE_FOLLOWER,
   REMOVE_FOLLOWER_SUCCESS,
-  REMOVE_FOLLOWER_FAILURE
+  REMOVE_FOLLOWER_FAILURE,
+  GET_FOLLOWING, 
+  GET_FOLLOWING_SUCCESSFUL,
+  GET_FOLLOWING_FAILURE,
 } from "../actions/index.js";
 
 export const FollowersReducer = (state = {}, action) => {
@@ -36,6 +39,11 @@ export const FollowersReducer = (state = {}, action) => {
         ...state,
         followers: action.payload
       };
+    case GET_FOLLOWING_SUCCESSFUL:
+      return {
+        ...state, 
+        usersFollowers: action.payload
+      }
     case GET_FOLLOWERS:
     case GET_USER_FOLLOWERS:
     case GET_USER_FOLLOWERS_FAILURE:
@@ -44,6 +52,8 @@ export const FollowersReducer = (state = {}, action) => {
     case ADD_FOLLOWER_FAILURE:
     case REMOVE_FOLLOWER:
     case REMOVE_FOLLOWER_FAILURE:
+    case GET_FOLLOWING: 
+    case GET_FOLLOWING_FAILURE:
     default:
       return state;
   }

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -79,6 +79,7 @@ const ProfileWrapper = styled.div`
     font-size: .8rem; 
     justify-content: flex-start;
     align-content : center; 
+    align-items : center; 
 
     &:hover {
       cursor: default; 

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import Spinner from '../assets/gif/spinner/Spinner'; //need to move to assets folder
 import { getProfile } from '../store/actions/index';
-import { getFollowers, getProfileFollowers, removeFollower, addFollower, inviteFriend } from '../store/actions/index';
+import { getFollowers, getProfileFollowers, removeFollower, addFollower, inviteFriend, followersCount } from '../store/actions/index';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { phoneP, phoneL, tabletP, tabletL } from '../globals/globals';
@@ -447,7 +447,7 @@ class Profile extends Component {
                   <Tab> Followed Posts</Tab>
                   <Tab>Comments</Tab>
                   <Tab>Replies</Tab>
-                  <Tab>Followers</Tab>
+                  <Tab>Users</Tab>
                 </TabList>
                 <TabPanel>
                   <WrappedDiv>
@@ -604,6 +604,7 @@ Profile.propTypes = {
   removeFollower : PropTypes.func, 
   addFollower : PropTypes.func,
   inviteFriend : PropTypes.func, 
+  followersCount : PropTypes.func, 
   setEditProfileModalRaised : PropTypes.func.isRequired,
   isEditProfileModalRaised : PropTypes.bool.isRequired, 
   toggleSearch : PropTypes.func.isRequired,
@@ -629,7 +630,8 @@ Profile.propTypes = {
 const mapStateToProps = state => ({
   profile: state.profilesData.singleProfileData,
   followers: state.followers,
-  profileFollowers : state.profileFollowers
+  profileFollowers : state.profileFollowers,
+  userFollowers : state.userFollowers,
 });
 
-export default connect(mapStateToProps, { getProfile,getFollowers, getProfileFollowers, removeFollower, addFollower, inviteFriend })(Profile);
+export default connect(mapStateToProps, { getProfile,getFollowers, getProfileFollowers, removeFollower, addFollower, inviteFriend, followersCount })(Profile);

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -73,6 +73,25 @@ const ProfileWrapper = styled.div`
       width: 80%;
     }
   }
+
+  .userfollowers-style {
+    margin-left: 0px; 
+    font-size: .8rem; 
+    justify-content: flex-start;
+    align-content : center; 
+
+    &:hover {
+      cursor: default; 
+      color: black; 
+      text-decoration: none;
+    }
+
+    @media (max-width: 395px ){
+      flex-direction: column; 
+    }
+
+  }
+
   @media ${phoneP} {
     margin-left: 0px;
     display: flex;
@@ -313,8 +332,13 @@ const ProfileLink = styled.a`
 `;
 
 const FollowSpan = styled.span`
-  margin-right: 20px; 
-  margin-left: 20px; 
+  margin-right: 15px; 
+  margin-left: 15px; 
+  text-align : center; 
+  &:hover {
+    text-decoration: none; 
+    color: black;
+  }
 `;
 
 /***************************************************************************************************
@@ -427,7 +451,11 @@ class Profile extends Component {
                   <p className='property-content'> {profile.username ? profile.username : <Deleted />}</p>
                   {profileId !== userId ? alreadyFollowing === false ? <Button className='add-post-btn' onClick = {this.handleAddFollower(userId, profileId)}>Follow</Button> : <Button className='add-post-btn' onClick = {this.handleRemoveFollower(userId, profileId)}>UnFollow</Button> : <Button className='add-post-btn' onClick = {this.editProfile}>Edit Profile</Button>}
                   <br/>
-                  <span><SpanLabel>Following: </SpanLabel>{profileFollowersCount}  </span><span>  <SpanLabel> Followers: </SpanLabel>{usersFollowersCount}</span>
+                  <WrappedDiv className = 'userfollowers-style'>
+
+                  <FollowSpan><SpanLabel>Following: </SpanLabel>{profileFollowersCount}  </FollowSpan><FollowSpan>  <SpanLabel> Followers: </SpanLabel>{usersFollowersCount}</FollowSpan>
+                  </WrappedDiv>
+
                 </WrappedDiv>
               </HeaderStyle>
               {/* This section is for the bio and the links for a user account */}

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -452,10 +452,9 @@ class Profile extends Component {
                   <p className='property-content'> {profile.username ? profile.username : <Deleted />}</p>
                   {profileId !== userId ? alreadyFollowing === false ? <Button className='add-post-btn' onClick = {this.handleAddFollower(userId, profileId)}>Follow</Button> : <Button className='add-post-btn' onClick = {this.handleRemoveFollower(userId, profileId)}>UnFollow</Button> : <Button className='add-post-btn' onClick = {this.editProfile}>Edit Profile</Button>}
                   <br/>
-                  <WrappedDiv className = 'userfollowers-style'>
-
+                 { profileId === userId ?  <WrappedDiv className = 'userfollowers-style'>
                   <FollowSpan><SpanLabel>Following: </SpanLabel>{profileFollowersCount}  </FollowSpan><FollowSpan>  <SpanLabel> Followers: </SpanLabel>{usersFollowersCount}</FollowSpan>
-                  </WrappedDiv>
+                  </WrappedDiv> : <span></span>}
 
                 </WrappedDiv>
               </HeaderStyle>

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -424,9 +424,9 @@ class Profile extends Component {
                   <p><SpanLabel>Bio </SpanLabel><span>{bio}</span></p>
                   <br/>
                   <p><SpanLabel>Location </SpanLabel> <span>{location}</span></p>
-                  <p><SpanLabel>Github </SpanLabel> <span><ProfileLink href={ github.includes("http://") === true ? `${github}` : `http://${github}`} target = "_blank">{github}</ProfileLink></span></p>
-                  <p><SpanLabel>LinkedIn </SpanLabel> <span><ProfileLink href={linkedin.includes("http://") === true ? `${linkedin}` : `http://${linkedin}`}  target = "_blank">{linkedin}</ProfileLink></span></p>
-                  <p><SpanLabel>Twitter </SpanLabel> <span><ProfileLink href={twitter.includes("http://") === true ? `${twitter}` : `http://${twitter}`} target = "_blank">{twitter}</ProfileLink></span></p>
+                  <p><SpanLabel>Github </SpanLabel> <span><ProfileLink href={ github.includes("http://") === true  || github.includes("https://") === true ? `${github}` : `http://${github}`} target = "_blank">{github}</ProfileLink></span></p>
+                  <p><SpanLabel>LinkedIn </SpanLabel> <span><ProfileLink href={linkedin.includes("http://") === true || linkedin.includes("https://") === true ? `${linkedin}` : `http://${linkedin}`}  target = "_blank">{linkedin}</ProfileLink></span></p>
+                  <p><SpanLabel>Twitter </SpanLabel> <span><ProfileLink href={twitter.includes("http://") === true || twitter.includes("https://") === true? `${twitter}` : `http://${twitter}`} target = "_blank">{twitter}</ProfileLink></span></p>
               </div>
               <br/>
               <WrappedDiv>

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -312,12 +312,18 @@ const ProfileLink = styled.a`
   }
 `;
 
+const FollowSpan = styled.span`
+  margin-right: 20px; 
+  margin-left: 20px; 
+`;
+
 /***************************************************************************************************
  ********************************************* Component *******************************************
  **************************************************************************************************/
 class Profile extends Component {
   state = {
-    initialized: false 
+    initialized: false,
+
   }
   componentDidMount() {
     this.props.getProfile(this.props.match.params.id);
@@ -339,6 +345,7 @@ class Profile extends Component {
     const userId = localStorage.getItem("symposium_user_id");
     this.props.getProfileFollowers(this.props.match.params.id); 
     this.props.getFollowers(userId);
+    this.props.followersCount(this.props.match.params.id);
   }
   /*double arrow functions prevent peformance issues because it will not create a new function on every render */
   handleAddFollower = (userId, followingId) => () => {
@@ -396,6 +403,8 @@ class Profile extends Component {
 
     const followListLength = followList ? followList.length : 0; 
 
+    const profileFollowersCount = this.props.followers.profileFollowers ?   this.props.followers.profileFollowers.length : 0;
+    const usersFollowersCount = this.props.followers.usersFollowers ? this.props.followers.usersFollowers.length : 0; 
     let profileItems;
     if (this.props.profile.length === 0) {
       profileItems = <Spinner />;
@@ -417,6 +426,8 @@ class Profile extends Component {
                 <WrappedDiv className='username-style'>
                   <p className='property-content'> {profile.username ? profile.username : <Deleted />}</p>
                   {profileId !== userId ? alreadyFollowing === false ? <Button className='add-post-btn' onClick = {this.handleAddFollower(userId, profileId)}>Follow</Button> : <Button className='add-post-btn' onClick = {this.handleRemoveFollower(userId, profileId)}>UnFollow</Button> : <Button className='add-post-btn' onClick = {this.editProfile}>Edit Profile</Button>}
+                  <br/>
+                  <span><SpanLabel>Following: </SpanLabel>{profileFollowersCount}  </span><span>  <SpanLabel> Followers: </SpanLabel>{usersFollowersCount}</span>
                 </WrappedDiv>
               </HeaderStyle>
               {/* This section is for the bio and the links for a user account */}


### PR DESCRIPTION
# Description
https://trello.com/c/hMuNw4Q4/23-publicly-showing-followers-and-follow-counts-for-users-this-version-should-leave-that-information-private


Followers count and users following the user count displayed on the profile.  
This version should leave that information private so you have to be the user logged in and on your profile to see this display. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?  in the local host browser checking out that the profile displays this data and all elements. 
- [x] Test A
Tested backend route,  tested front end. Styling also tested in mobile view and made adjustments. 
Because other users have followers and are being followed based off the seeds for them I first displayed it on every profile. 

![image](https://user-images.githubusercontent.com/38900224/55821654-9798b200-5ac3-11e9-9e13-ec6a9a36e142.png)

I then removed this from every profile only displaying it on the profile of the user logged in. 
![image](https://user-images.githubusercontent.com/38900224/55821688-aa12eb80-5ac3-11e9-99de-38fc70ee61a4.png)

![image](https://user-images.githubusercontent.com/38900224/55821712-b8610780-5ac3-11e9-9b95-6f2c553509e6.png)

Mobile view had issues under  390 px so I changed the flex direction to column 

![image](https://user-images.githubusercontent.com/38900224/55821756-d169b880-5ac3-11e9-99b3-977a02a1718d.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
