### PR TITLE
Jonathan holloway

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -288,7 +288,7 @@ class App extends Component {
     if (user_id && token) return this.props.logBackIn(user_id, token);
   }
   componentDidUpdate(prevProps) {
-    if (this.props.error.includes('expired')) {
+    if (this.props.error && this.props.error.includes('expired')) {
       localStorage.clear();
     }
     if (

--- a/frontend/src/store/actions/EditProfileActions.js
+++ b/frontend/src/store/actions/EditProfileActions.js
@@ -7,7 +7,7 @@ import { handleError } from "../../helpers/index.js";
 import { backendUrl } from "../../globals/globals.js";
 
 //action creator
-import { getProfile } from "../../store/actions/index.js";
+// import { getProfile } from "../../store/actions/index.js";
 
 
 /***************************************************************************************************

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -646,7 +646,7 @@ class Profile extends Component {
                       <div>
                         {followListLength > 0 ? followList.map((user, id) =>
                           // user.following_id can be used to go to the users profile upon clicking on them currently not implemented. 
-                          <DivFollowListItem>
+                          <DivFollowListItem key = {id}>
                             <WrappedDiv
                               style={{ cursor: "pointer" }}
                               key={id}

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -647,6 +647,7 @@ class Profile extends Component {
                         {followListLength > 0 ? followList.map((user, id) =>
                           // user.following_id can be used to go to the users profile upon clicking on them currently not implemented. 
                           <DivFollowListItem key = {id}>
+                           <ContentDiv key = {id}>
                             <WrappedDiv
                               style={{ cursor: "pointer" }}
                               key={id}
@@ -662,6 +663,7 @@ class Profile extends Component {
                               <span>{user.username}</span>
 
                             </WrappedDiv>
+                            </ContentDiv>
                           </DivFollowListItem>
                         ) : <div>{profileId !== userId ? `${usernameForProfile} currently doesn't follow any users.` : "You are not currently following any users."}</div>}
 

--- a/frontend/src/views/ProfileView.js
+++ b/frontend/src/views/ProfileView.js
@@ -698,8 +698,8 @@ Profile.propTypes = {
   isEditProfileModalRaised: PropTypes.bool.isRequired,
   toggleSearch: PropTypes.func.isRequired,
   showSearch: PropTypes.bool.isRequired,
-  setInviteFriendModalRaised: PropTypes.func.isRequired,
-  isInviteFriendModalRaised: PropTypes.bool.isRequired,
+  setInviteFriendModalRaised: PropTypes.func,
+  isInviteFriendModalRaised: PropTypes.bool,
 
   profile: PropTypes.arrayOf(
     PropTypes.shape({


### PR DESCRIPTION
# Description

Fixed serveral warnings that showed up in the console.   Also fixed the following users section to match the other sections.  
![image](https://user-images.githubusercontent.com/38900224/56164391-33c82a80-5f96-11e9-85e1-2f7a51b9331e.png)

![image](https://user-images.githubusercontent.com/38900224/56165713-4c860f80-5f99-11e9-95ae-005ce3748451.png)

When you hover over^^ 

scrolling over highlights it like other sections and the spacing matches the other sections as the ux instructor stated he liked from the other sections. 



Changed the position of the edit profile button. Because I used two ternary conditionals to display only one button but make use of three buttons (unfollow follow and edit profile) I had to separate this out so that the follow/ unfollow buttons stated in the same place but only the edit profile button was removed. Voted on position with the team.  

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?  in the local host browser checking out that the profile displays this data and all elements. 
- [x] Test A
Well I tested out mobile view  

Tested out the look in the profile spacing good able to click on users functionality works. 


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
